### PR TITLE
GitHub Linguist support for adblock rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt linguist-detectable

--- a/Anifiltrs Extra.txt
+++ b/Anifiltrs Extra.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Anifiltrs/Extra 🍮
 ! Expires: 3 days
 ! Homepage: https://github.com/Karmesinrot/Anifiltrs

--- a/Anifiltrs Main/Anifiltrs extra-main.txt
+++ b/Anifiltrs Main/Anifiltrs extra-main.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Anifiltrs/Extra—main 🥪
 ! Expires: 3 days
 ! Homepage: https://github.com/Karmesinrot/Anifiltrs

--- a/Anifiltrs — skeletonise.txt
+++ b/Anifiltrs — skeletonise.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Anifiltrs — 🥡 skeletonise
 ! Expires: 1 days
 ! Homepage: https://github.com/Karmesinrot/Anifiltrs

--- a/Anifltrs.txt
+++ b/Anifltrs.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Anifiltrs — 🍱 Anime streaming & Manga reading
 ! Expires: 1 days
 ! Homepage: https://github.com/Karmesinrot/Anifiltrs

--- a/Anime DL/Anime DL non-intrusive ads.txt
+++ b/Anime DL/Anime DL non-intrusive ads.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Anime DL non-intrusive ads
 ! Expires: 14 days
 ! Homepage: https://github.com/Karmesinrot/Anifiltrs

--- a/Anime DL/Anime DL.txt
+++ b/Anime DL/Anime DL.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Anime DL
 ! Expires: 7 days
 ! Homepage: https://github.com/Karmesinrot/Anifiltrs

--- a/Blur Preview Thumbnails/BPT—Experimental.txt
+++ b/Blur Preview Thumbnails/BPT—Experimental.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Anifiltrs — 🍹 Blur Preview Thumbnails Experimental
 ! Expires: 8 days
 ! Homepage: https://github.com/Karmesinrot/Anifiltrs

--- a/Blur Preview Thumbnails/Blur preview thumbnails.txt
+++ b/Blur Preview Thumbnails/Blur preview thumbnails.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Anifiltrs — 🍶 Blur Preview Thumbnails
 ! Expires: 8 days
 ! Homepage: https://github.com/Karmesinrot/Anifiltrs

--- a/Miscellaneous/RoselynPersonalFilters.txt
+++ b/Miscellaneous/RoselynPersonalFilters.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Roselyn's[Karmesinrot] Personal Filters
 ! Expires: 14 days
 ! Homepage: https://github.com/Karmesinrot/Anifiltrs

--- a/Social Distractions/Social Distractions.txt
+++ b/Social Distractions/Social Distractions.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Anifiltrs — 🍵 Anti social distractions
 ! Expires: 7 days
 ! Homepage: https://github.com/Karmesinrot/Anifiltrs


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401